### PR TITLE
Implement a basic ping server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+server/server

--- a/build_server.sh
+++ b/build_server.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eux
+
+(cd server; go get -t -d -v ./... && go build -v)

--- a/server/openprinter.go
+++ b/server/openprinter.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	http.HandleFunc("/ping", ping)
+
+	log.Printf("Listening on Port %s\n", port)
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}
+
+func ping(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, "pong")
+}


### PR DESCRIPTION
A simple server that listens on 8080 (by default) and returns ‘pong’ on the ‘/ping’ endpoint. This is just as a starting point for our server.