### PR TITLE
Configure Docker + add run_server script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # openprinter
+
+## Running
+This project uses [docker](https://www.docker.com) (and docker compose) for 
+deployment.
+
+To run the server, run
+
+```shell
+./run_server.sh
+```
+
+This will listen on port 8080 by default, change the `ports:` setting
+variable in the `docker-compose.yml` file for the `ping-server:` to override.
+
+e.g. `"8080:9000"` will configure the external port `9000` to be mapped to the
+internal port `8080`. This gives the apparent behaviour of actually listening
+on port `9000`, even though the server inside the container believes it is
+running on port `8080`.
+
+If you wish to change the internal port, you should set the `PORT` environment 
+variable in the container's Dockerfile and then update it on the LHS.

--- a/build_server.sh
+++ b/build_server.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -eux
-
-(cd server; go get -t -d -v ./... && go build -v)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2'
+services:
+  ping-server:
+    build: server/
+    restart: always
+    command: ./server/server
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: 8080

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eu
+
+docker-machine env default
+eval $(docker-machine env default)
+docker-compose up --build -d
+echo IP address: $(docker-machine ip default)

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:latest
+MAINTAINER jonathanlking@me.com
+EXPOSE 8080
+
+COPY . server/
+RUN cd server && go get -t -d -v ./... && go build -v


### PR DESCRIPTION
Create docker container for `ping-server` and compose for whole project. `build_server` has been converted to `run_server`, which switches to the `default` docker machine, rebuilds the docker containers (if necessary) and then deploys (locally).